### PR TITLE
Close Keyboard if User Taps Outside [SPEN-56]

### DIFF
--- a/Development/app/src/main/java/com/team4/walletwatch/Main/Tab1Fragment.kt
+++ b/Development/app/src/main/java/com/team4/walletwatch/Main/Tab1Fragment.kt
@@ -1,12 +1,11 @@
 package com.team4.walletwatch
 
+import android.content.Context
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
-import android.view.Gravity
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
+import android.view.*
+import android.view.inputmethod.InputMethodManager
 import android.widget.*
 import androidx.fragment.app.Fragment
 import me.abhinay.input.CurrencyEditText
@@ -257,6 +256,15 @@ class Tab1Fragment : Fragment() {
         /* Set the listener to reveal the CalendarView and its background. */
         dateButton.setOnClickListener {
             toggleDateSelector(true)
+            /* Hide the keyboard. */
+            (main.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager)
+                .hideSoftInputFromWindow(amountInput.windowToken, 0)
+        }
+
+        rootView.setOnTouchListener { _: View, _: MotionEvent ->
+            /* Hide the keyboard. */
+            (main.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager)
+                .hideSoftInputFromWindow(amountInput.windowToken, 0)
         }
 
         return rootView

--- a/Development/app/src/main/java/com/team4/walletwatch/Settings/CategoryFragment.kt
+++ b/Development/app/src/main/java/com/team4/walletwatch/Settings/CategoryFragment.kt
@@ -1,12 +1,15 @@
 package com.team4.walletwatch
 
+import android.content.Context
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
+import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.InputMethodManager
 import android.widget.Button
 import android.widget.EditText
 
@@ -122,6 +125,12 @@ class CategoryFragment : Fragment() {
 
             override fun afterTextChanged(s: Editable) {}
         })
+
+        rootView.setOnTouchListener { _: View, _: MotionEvent ->
+            /* Hide the keyboard. */
+            (settings.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager)
+                .hideSoftInputFromWindow(category1Edit.windowToken, 0)
+        }
 
         return rootView
     }


### PR DESCRIPTION
Annoyingly, the keyboard/numpad would only close if the user tapped the close down-arrow.
Now tapping anywhere outside of the keyboard/numpad/textbox will close it.
Additionally, tapping the date selector button will close the keyboard, so as not to obscure the calendar.