### PR TITLE
Fixed Line Chart Y-axis Labels [SPEN-55]

### DIFF
--- a/Development/app/src/main/java/com/spendsages/walletwatch/DataManager.kt
+++ b/Development/app/src/main/java/com/spendsages/walletwatch/DataManager.kt
@@ -265,7 +265,7 @@ object DataManager {
     private fun findExistingDateTags(doc : Document, category: String,
                                      year : String, month : String, day : String) : Int {
         var id = "c-$category-$year"
-        var xpath = "string(/root/data/category[@id=\"c-$category\"]/year[@id=\"$id\"]/month[@id=\""
+        var xpath = "string(/root/category[@id=\"c-$category\"]/year[@id=\"$id\"]/month[@id=\""
         var dateExists = 0
 
         if (getValueByID(doc, id) != null) {

--- a/Development/app/src/main/res/layout/fragment_tab2.xml
+++ b/Development/app/src/main/res/layout/fragment_tab2.xml
@@ -100,7 +100,7 @@
 
             <TextView
                 android:id="@+id/category1Text"
-                android:layout_width="206dp"
+                android:layout_width="200dp"
                 android:layout_height="match_parent"
                 android:paddingHorizontal="5dp"
                 android:textAlignment="viewStart"
@@ -143,7 +143,7 @@
 
             <TextView
                 android:id="@+id/category2Text"
-                android:layout_width="206dp"
+                android:layout_width="200dp"
                 android:layout_height="match_parent"
                 android:paddingHorizontal="5dp"
                 android:textAlignment="viewStart"
@@ -188,7 +188,7 @@
 
             <TextView
                 android:id="@+id/category3Text"
-                android:layout_width="206dp"
+                android:layout_width="200dp"
                 android:layout_height="match_parent"
                 android:paddingHorizontal="5dp"
                 android:textAlignment="viewStart"
@@ -232,7 +232,7 @@
 
             <TextView
                 android:id="@+id/allText"
-                android:layout_width="206dp"
+                android:layout_width="200dp"
                 android:layout_height="match_parent"
                 android:paddingHorizontal="5dp"
                 android:textAlignment="viewStart"


### PR DESCRIPTION
Implemented formatting rules for Y-axis labels:
< 10: Show 2 decimals.
>= 10 & < 1,000: Show no decimals.
>= 1,000: Show no decimals and use metric prefix.
Also resize totals as to fit amounts up to, but not including one billion.
Also fixed bug in XPath expression of findExistingDateTags that referenced "data" tag, which no longer exists.